### PR TITLE
Updated for new API

### DIFF
--- a/src/main.ml
+++ b/src/main.ml
@@ -140,7 +140,11 @@ let main (vm: string) path backend max_indirect_segments =
     ) [ Sys.sigint; Sys.sigterm ];
 
   lwt () = S'.create name device in
-  lwt stats = S'.run ~max_indirect_segments configuration.filename name device in
+
+  match_lwt S.connect configuration.filename with
+  | `Error _err -> fail (Failure "Failed to connect to backend device")
+  | `Ok backend_dev ->
+  lwt stats = S'.run ~max_indirect_segments backend_dev name device in
   Printf.fprintf stderr "# ring occupancy stats\n";
   Printf.fprintf stderr "# slots-occupied frequency\n";
   Array.iteri (fun i n -> if n <> 0 then Printf.fprintf stderr "%d %d\n" i n) stats.Blkback.ring_utilisation;

--- a/src/storage.ml
+++ b/src/storage.ml
@@ -15,5 +15,8 @@ type configuration = {
   filename: string;
   backend: string option;
 }
-module type BLOCK = V1_LWT.BLOCK
-  with type id = string
+module type BLOCK = sig
+  include V1_LWT.BLOCK
+    with type id = string
+  val connect : string -> [`Ok of t | `Error of error] io
+end


### PR DESCRIPTION
Blkback.run now takes a device, not a device name.

This is untested, but compiles! The error reporting isn't great, but that can be updated once `error_message` is more widely available...
